### PR TITLE
Add missing build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends: texinfo (>= 4.11-2),
                autoconf,
                automake1.11,
                autotools-dev,
-               libffi-dev (>= 3.0)
+               libffi-dev (>= 3.0),
+               pkg-config
 Build-Conflicts: autoconf2.13, automake1.4
 Homepage: http://sawfish.wikia.com/
 


### PR DESCRIPTION
Missing pkg-config caused pbuilder to fail.

The error code was something like "possibly undefined macro: AC_MSG_ERROR". Adding this build-dep made the error go away.
