### PR TITLE
Fixed rules.mk. variables should not be recursive

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,29 @@
+# rules.mk
+
+prefix=/usr
+datadir=${datarootdir}
+libdir=${prefix}/lib/x86_64-linux-gnu
+
+# shut up configure
+datarootdir=${prefix}/share
+
+repdir:=${datadir}/rep
+repcommonexecdir:=${libdir}/rep
+rpath_repcommonexecdir:=${libdir}/rep
+
+rep_LIBTOOL:=$(repcommonexecdir)/libtool --tag CC
+rep_INSTALL_ALIASES:=$(repcommonexecdir)/install-aliases
+
+# use this like:
+# foo.la : foo.lo bar.lo
+#	$(rep_DL_LD) link-opts...
+
+rep_DL_LD:=$(rep_LIBTOOL) --mode=link --tag=CC $(CC) -avoid-version -module -rpath $(rpath_repcommonexecdir)
+
+rep_DL_INSTALL:=$(rep_LIBTOOL) --mode=install $(INSTALL)
+rep_DL_UNINSTALL:=$(rep_LIBTOOL) --mode=uninstall rm
+
+# Rule for libtool controlled C objects
+%.lo : %.c
+	$(rep_LIBTOOL) --mode=compile --tag=CC $(CC) -c $(CPPFLAGS) $(CFLAGS) $<
+


### PR DESCRIPTION
Sawfish uses rep_LIBTOOL. This is done by including librep/rules.mk

the problem is that these variables are set to be recursive. This means that when rep_LIBTOOL is used, it uses the current $prefix. It should not. It should be defined non-recursively. This patch fixes that problem

--dmg
