### PR TITLE
Some variables should not be recursive because they depend on 'prefix', ...

### DIFF
--- a/rules.mk.in
+++ b/rules.mk.in
@@ -7,12 +7,12 @@ libdir=@libdir@
 # shut up configure
 datarootdir=@datarootdir@
 
-repdir=@repdir@
-repcommonexecdir=@repcommonexecdir@
-rpath_repcommonexecdir=@repcommonexecdir@
+repdir:=@repdir@
+repcommonexecdir:=@repcommonexecdir@
+rpath_repcommonexecdir:=@repcommonexecdir@
 
-rep_LIBTOOL=$(repcommonexecdir)/libtool --tag CC
-rep_INSTALL_ALIASES=$(repcommonexecdir)/install-aliases
+rep_LIBTOOL:=$(repcommonexecdir)/libtool --tag CC
+rep_INSTALL_ALIASES:=$(repcommonexecdir)/install-aliases
 
 # use this like:
 # foo.la : foo.lo bar.lo


### PR DESCRIPTION
...which might be different when used than when installed

For example, currently if librep is installed in /usr but sawfish is build for /usr/local then rep_LIBTOOL will point to /usr/local/lib/rep/libtool


--dmg