### PR TITLE
rules.mk.in: Cleanup.

### DIFF
--- a/rules.mk.in
+++ b/rules.mk.in
@@ -1,13 +1,5 @@
 # rules.mk
 
-prefix=@prefix@
-datadir=@datadir@
-libdir=@libdir@
-
-# shut up configure
-datarootdir=@datarootdir@
-
-repdir:=@repdir@
 repcommonexecdir:=@repcommonexecdir@
 rpath_repcommonexecdir:=@repcommonexecdir@
 

--- a/rules.mk.in
+++ b/rules.mk.in
@@ -1,7 +1,7 @@
 # rules.mk
 
-repcommonexecdir:=@repcommonexecdir@
-rpath_repcommonexecdir:=@repcommonexecdir@
+repcommonexecdir?=$(shell pkg-config --variable=repcommonexecdir librep)
+rpath_repcommonexecdir:=$(repcommonexecdir)
 
 rep_LIBTOOL:=$(repcommonexecdir)/libtool --tag CC
 rep_INSTALL_ALIASES:=$(repcommonexecdir)/install-aliases


### PR DESCRIPTION
Hi, #4 will make `repcommonexecdir` expand to `${exec_prefix}/lib/rep`
, so it doesn't really work.

IIUC, the goal of `rules.mk` is provide `Rule for libtool controlled C objects`,
it should not set `prefix, datadir ...`, which may cause problems. 
(eg: I see you have to adjust the order for sawfish's Makefile to not override prefix)

And, rep_LIBTOOL should be an absolute path, I think pkg-config just do the trick.

PS: I'm packaging sawfish for Guix, which every package must install to its seperate directory.
