### PR TITLE
Fix broken news.texi file

### DIFF
--- a/man/news.texi
+++ b/man/news.texi
@@ -8,6 +8,7 @@
 @item Assume @code{stack-direction} upwards for @code{hppa} and @code{metag} arches. (Debian patch) [Helge Deller]
 
 @item Update @code{librep.spec} [Allan Duncan]
+@end itemize
 
 @heading 0.92.6
 @itemize @bullet


### PR DESCRIPTION
news.texi had a syntax error that prevented building the
documentation.  Fix.