### PR TITLE
Make doc-strings build reproducibly

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -72,7 +72,7 @@ uninstall :
 	rm -f $(DESTDIR)$(libdir)/pkgconfig/librep.pc
 
 doc-strings : src/repdoc
-	src/repdoc doc-strings `find $(top_srcdir) -name '*.c' -print`
+	src/repdoc doc-strings `find $(top_srcdir) -name '*.c' -print|LC_ALL=C sort`
 
 src/repdoc :
 	( cd src && $(MAKE) repdoc )

--- a/lisp/rep/vm/compiler.jl
+++ b/lisp/rep/vm/compiler.jl
@@ -312,7 +312,7 @@ EXCLUDE-RE may be a regexp matching files which shouldn't be compiled."
 				 (file-newer-than-file-p abs-file c-name))
 			 (report-progress abs-file)
 			 (compile-file abs-file))))))))
-	(directory-files dir-name))
+	(sort (directory-files dir-name) <))
   t)
 
 (defun compile-lisp-lib (#!optional directory force-p)


### PR DESCRIPTION
by sorting input file lists.
Also helps fix https://github.com/SawfishWM/sawfish/issues/31

In other lisp implementations directory-files returns sorted results
by default but not in rep, so we have to sort.