### PR TITLE
build: Respect $(LIBTOOL)

### DIFF
--- a/Makedefs.in
+++ b/Makedefs.in
@@ -83,7 +83,6 @@ COMPILE_ENV = REPLISPDIR=$(top_builddir)/lisp \
 	      REPDOCFILE=$(top_builddir)/doc-strings
 
 include $(top_srcdir)/rules.mk
-rep_LIBTOOL=@LIBTOOL@
 
 # Rule for ``normal'' C objects
 %.o : %.c

--- a/rules.mk.in
+++ b/rules.mk.in
@@ -3,19 +3,18 @@
 repcommonexecdir?=$(shell pkg-config --variable=repcommonexecdir librep)
 rpath_repcommonexecdir:=$(repcommonexecdir)
 
-rep_LIBTOOL:=$(repcommonexecdir)/libtool --tag CC
 rep_INSTALL_ALIASES:=$(repcommonexecdir)/install-aliases
 
 # use this like:
 # foo.la : foo.lo bar.lo
 #	$(rep_DL_LD) link-opts...
 
-rep_DL_LD=$(rep_LIBTOOL) --mode=link --tag=CC $(CC) -avoid-version -module -rpath $(rpath_repcommonexecdir)
+rep_DL_LD=$(LIBTOOL) --mode=link --tag=CC $(CC) -avoid-version -module -rpath $(rpath_repcommonexecdir)
 
-rep_DL_INSTALL=$(rep_LIBTOOL) --mode=install $(INSTALL)
-rep_DL_UNINSTALL=$(rep_LIBTOOL) --mode=uninstall rm
+rep_DL_INSTALL=$(LIBTOOL) --mode=install $(INSTALL)
+rep_DL_UNINSTALL=$(LIBTOOL) --mode=uninstall rm
 
 # Rule for libtool controlled C objects
 %.lo : %.c
-	$(rep_LIBTOOL) --mode=compile --tag=CC $(CC) -c $(CPPFLAGS) $(CFLAGS) $<
+	$(LIBTOOL) --mode=compile --tag=CC $(CC) -c $(CPPFLAGS) $(CFLAGS) $<
 


### PR DESCRIPTION
When building librep with slibtool (https://dev.midipix.org/cross/slibtool) it will ignore the value of `$(LIBTOOL)` in a few places which ends up with the build attempting to use both slibtool and GNU libtool which will not work. It is better to consistently use `$(LIBTOOL)` so that either libtool implementation can be used.

This can be fixed by simply removing `rep_LIBTOOL`.

Please see this downstream issue: https://bugs.gentoo.org/790812

Note: librep will not fully build with slibtool yet, there also appears to be an issue on the slibtool side with `--mode=execute` which should hopefully be resolvable soon, but regardless this fix would be helpful sooner rather than later. The build should of course continue to work with GNU libtool in the mean time.

