### PR TITLE
Set stack direction is downwards on loongarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -540,7 +540,7 @@ AC_ARG_WITH(stack-direction,
  [with_stack_direction=unknown])
 if test "${with_stack_direction}" = unknown; then
   case ${host_cpu} in
-    sparc*|i?86*|powerpc*|x86_64*|arm*|aarch64*|s390*|mips*|alpha*|ia64*)
+    sparc*|i?86*|powerpc*|x86_64*|arm*|aarch64*|s390*|mips*|alpha*|ia64*|loongarch64*)
       AC_MSG_RESULT([assuming downwards])
       with_stack_direction="-1"
       ;;


### PR DESCRIPTION
Hi maintainers,

Compiling the librep failed for loong64 in the Debian Package Auto-Building environment.
The error log is as follows,
```
REPLISPDIR=../lisp REP_DL_LOAD_PATH=../src/.libexec REPDOCFILE=../doc-strings ../src/rep --batch -l rep.vm.compiler \
  -f compile-batch rep-xgettext.jl \
&& mv rep-xgettext.jlc rep-xgettext && chmod +x rep-xgettext
 ** error: --with-stack-direction is incorrect; it should be -1
make[3]: *** [Makefile:182: rep-xgettext] Error 10
make[3]: Leaving directory '/<<PKGBUILDDIR>>/src'
.......
```
The full build log can be found at https://buildd.debian.org/status/fetch.php?pkg=librep&arch=loong64&ver=0.92.7-2&stamp=1740809161&raw=0.

Need to set stack direction is downwards on loongarch64.
Based on this commit, librep (0.92.7-2+loong64) was built successfully on locally.
```
......
  dh_builddeb
dpkg-deb: building package 'rep-dbgsym' in '../rep-dbgsym_0.92.7-2+loong64_loong64.deb'.
dpkg-deb: building package 'librep16' in '../librep16_0.92.7-2+loong64_loong64.deb'.
dpkg-deb: building package 'rep' in '../rep_0.92.7-2+loong64_loong64.deb'.
dpkg-deb: building package 'librep-dev' in '../librep-dev_0.92.7-2+loong64_loong64.deb'.
dpkg-deb: building package 'librep-dev-dbgsym' in '../librep-dev-dbgsym_0.92.7-2+loong64_loong64.deb'.
dpkg-deb: building package 'librep16-dbgsym' in '../librep16-dbgsym_0.92.7-2+loong64_loong64.deb'.
dpkg-deb: building package 'rep-doc' in '../rep-doc_0.92.7-2+loong64_all.deb'.
 dpkg-genbuildinfo -O../librep_0.92.7-2+loong64_loong64.buildinfo
 dpkg-genchanges -O../librep_0.92.7-2+loong64_loong64.changes
```

Please review.

Best regards,
Dandan Zhang